### PR TITLE
fix(android): make SQLCipher optional and prevent crash when missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,27 @@ Add to your `AndroidManifest.xml` if needed:
 </application>
 ```
 
-## Encryption (iOS/Android)
+## Encryption (Android)
 
-Set `encrypted: true` and provide an `encryptionKey` when connecting. This uses SQLCipher on mobile platforms (ensure SQLCipher is linked on iOS if you use SwiftPM).
+Encryption uses [SQLCipher](https://www.zetetic.net/sqlcipher/) and is opt-in. Add the SQLCipher dependency to your **app-level** `build.gradle`:
+
+```gradle
+dependencies {
+    implementation 'net.zetetic:sqlcipher-android:4.13.0'
+}
+```
+
+Then connect with encryption enabled:
+
+```typescript
+const db = await FastSQL.connect({
+  database: 'secure',
+  encrypted: true,
+  encryptionKey: 'my-secret-key',
+});
+```
+
+If SQLCipher is not installed and `encrypted: true` is passed, the plugin returns a clear error message instead of crashing.
 
 ## Usage
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -258,6 +258,41 @@ class OTSyncEngine {
 }
 ```
 
+## Encryption (Android)
+
+Encryption is optional and uses [SQLCipher](https://www.zetetic.net/sqlcipher/). The plugin ships with SQLCipher as a compile-time dependency only — it is **not** bundled by default.
+
+### Enabling Encryption
+
+Add the SQLCipher runtime dependency to your **app-level** `android/app/build.gradle`:
+
+```gradle
+dependencies {
+    implementation 'net.zetetic:sqlcipher-android:4.13.0'
+}
+```
+
+Then connect with encryption:
+
+```typescript
+const db = await FastSQL.connect({
+  database: 'secure',
+  encrypted: true,
+  encryptionKey: 'my-secret-key',
+});
+```
+
+### What Happens Without SQLCipher
+
+If you pass `encrypted: true` without the SQLCipher dependency, the plugin returns a descriptive error:
+
+> Encryption is not available. Add `implementation "net.zetetic:sqlcipher-android:4.13.0"` to your app's build.gradle to enable encryption.
+
+The app will **not** crash — the error is caught gracefully at two levels:
+
+1. **Class check**: Before attempting to load `EncryptedSQLDatabase`, the plugin verifies the SQLCipher class is on the classpath via `Class.forName`.
+2. **Native library check**: `EncryptedSQLDatabase` catches `UnsatisfiedLinkError` from `System.loadLibrary("sqlcipher")` and converts it to a descriptive exception.
+
 ## Troubleshooting
 
 ### iOS: Server Not Starting

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     implementation 'androidx.sqlite:sqlite:2.6.2'
     implementation 'com.google.code.gson:gson:2.13.2'
     implementation 'org.nanohttpd:nanohttpd:2.3.1'
-    implementation 'net.zetetic:sqlcipher-android:4.13.0'
+    compileOnly 'net.zetetic:sqlcipher-android:4.13.0'
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/android/src/main/java/app/capgo/capacitor/fastsql/CapgoCapacitorFastSqlPlugin.java
+++ b/android/src/main/java/app/capgo/capacitor/fastsql/CapgoCapacitorFastSqlPlugin.java
@@ -57,6 +57,16 @@ public class CapgoCapacitorFastSqlPlugin extends Plugin {
             // Open database
             DatabaseConnection db;
             if (encrypted) {
+                try {
+                    Class.forName("net.zetetic.database.sqlcipher.SQLiteDatabase");
+                } catch (ClassNotFoundException e) {
+                    call.reject(
+                        "Encryption is not available. " +
+                            "Add 'implementation \"net.zetetic:sqlcipher-android:4.13.0\"' " +
+                            "to your app's build.gradle to enable encryption."
+                    );
+                    return;
+                }
                 db = new EncryptedSQLDatabase(dbFile.getAbsolutePath(), encryptionKey);
             } else {
                 db = new SQLDatabase(dbFile.getAbsolutePath());

--- a/android/src/main/java/app/capgo/capacitor/fastsql/EncryptedSQLDatabase.java
+++ b/android/src/main/java/app/capgo/capacitor/fastsql/EncryptedSQLDatabase.java
@@ -23,6 +23,16 @@ public class EncryptedSQLDatabase implements DatabaseConnection {
         if (encryptionKey == null || encryptionKey.isEmpty()) {
             throw new Exception("Encryption key is required when encrypted is true");
         }
+        try {
+            System.loadLibrary("sqlcipher");
+        } catch (UnsatisfiedLinkError e) {
+            throw new Exception(
+                "SQLCipher native library not found. " +
+                    "Add 'implementation \"net.zetetic:sqlcipher-android:4.13.0\"' " +
+                    "to your app's build.gradle to enable encryption.",
+                e
+            );
+        }
         byte[] keyBytes = encryptionKey.getBytes(StandardCharsets.UTF_8);
         this.db = SQLiteDatabase.openOrCreateDatabase(path, keyBytes, null, null);
         // Enable foreign keys

--- a/example-app/android/app/build.gradle
+++ b/example-app/android/app/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation project(':capacitor-cordova-android-plugins')
+    implementation 'net.zetetic:sqlcipher-android:4.13.0'
 }
 
 apply from: 'capacitor.build.gradle'


### PR DESCRIPTION
## What
- Make SQLCipher an opt-in dependency on Android instead of mandatory
- Prevent fatal crash when `encrypted: true` is used without SQLCipher installed

## Why
SQLCipher was bundled via `implementation` in the plugin's `build.gradle`, meaning every app using this plugin shipped SQLCipher whether they needed encryption or not. Worse, requesting `encrypted: true` without the native library available would crash the app with an `UnsatisfiedLinkError` — an `Error`, not an `Exception` — which the existing `catch (Exception e)` block could not catch.

## How
1. **`android/build.gradle`**: Changed `implementation` → `compileOnly` for `net.zetetic:sqlcipher-android:4.13.0`. The plugin compiles against SQLCipher but does not bundle it. Apps opt in by adding the dependency to their own `build.gradle`.
2. **`CapgoCapacitorFastSqlPlugin.java`**: Added `Class.forName("net.zetetic.database.sqlcipher.SQLiteDatabase")` check before attempting to instantiate `EncryptedSQLDatabase`. Returns a clear error via `call.reject()` if SQLCipher is not on the classpath.
3. **`EncryptedSQLDatabase.java`**: Added `try { System.loadLibrary("sqlcipher"); } catch (UnsatisfiedLinkError e)` in the constructor, converting the uncatchable `Error` into a descriptive `Exception`.
4. **`README.md` / `SETUP.md`**: Documented the opt-in encryption setup with Gradle snippet and explained the two-level graceful failure behavior.
5. **`example-app/android/app/build.gradle`**: Added `implementation 'net.zetetic:sqlcipher-android:4.13.0'` so the example app can test encryption.

## Testing
- `bun run build` ✅
- `bun run verify:android` ✅ (BUILD SUCCESSFUL)
- `bun run verify:ios` ✅ (BUILD SUCCEEDED — no iOS changes, just verifying no regression)
- `bun run verify:web` ✅
- `bun run fmt` ✅

## Not Tested
- On-device encrypted database creation (requires physical device or emulator with the example app deployed)
- Verifying the error message surfaces correctly in JS when SQLCipher is absent (requires a build without the dependency + encrypted: true call)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Android encryption support using SQLCipher with clear error messaging when the library is not installed.

* **Documentation**
  * Updated documentation with Android-specific encryption setup instructions and code examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->