### PR TITLE
[codex] add RAG vector store helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This plugin provides direct native SQLite database access with a custom communic
 - **Sync-Friendly**: Designed for local sync systems (CRDTs, operational transforms, etc.)
 - **IndexedDB Replacement**: Provides reliable alternative to broken/limited IndexedDB implementations
 - **Cross-Platform**: iOS, Android, and Web (using sql.js + IndexedDB for persistence)
+- **Optional RAG VectorStore**: Persist many named vector stores for retrieval-augmented generation without adding a native dependency
 
 ## iOS Configuration
 
@@ -237,6 +238,62 @@ const kv = await KeyValueStore.open({
 await kv.set('session', { token: 'abc123', expiresAt: 1710000000 });
 const session = await kv.get('session');
 await kv.remove('session');
+```
+
+### RAG Vector Stores (Optional)
+
+`FastSQLVectorStore` provides a dependency-free VectorStore-compatible helper inspired by `@react-native-rag/op-sqlite`. It stores embeddings in SQLite as binary Float32 vectors and computes cosine similarity in TypeScript, so it works anywhere this plugin works.
+
+Each store is namespaced by the `store` option, so one database can hold as many independent vector stores as you need:
+
+```typescript
+import { FastSQLVectorStore } from '@capgo/capacitor-fast-sql';
+
+const docs = await FastSQLVectorStore.open({
+  database: 'rag',
+  store: 'docs',
+  embeddings,
+});
+
+const tickets = await FastSQLVectorStore.open({
+  database: 'rag',
+  store: 'tickets',
+  embeddings,
+});
+
+await docs.add({
+  document: 'Capgo ships instant updates for Capacitor apps.',
+  metadata: { source: 'docs' },
+});
+
+const results = await docs.query({
+  queryText: 'How do instant updates work?',
+  nResults: 3,
+});
+
+await docs.close();
+await tickets.close();
+```
+
+You can also use precomputed embeddings without an embeddings provider:
+
+```typescript
+const store = await FastSQLVectorStore.open({
+  database: 'rag',
+  store: 'offline-embeddings',
+  embeddingDimension: 384,
+});
+
+await store.add({
+  id: 'intro',
+  document: 'Local RAG entry',
+  embedding: [0.12, 0.08, 0.31 /* ...384 values */],
+});
+
+const matches = await store.query({
+  queryEmbedding: [0.11, 0.09, 0.29 /* ...384 values */],
+  nResults: 5,
+});
 ```
 
 > Note: Web support is intended for minimal testing only. The primary focus is iOS/Android.

--- a/ios/Sources/CapgoCapacitorFastSqlPlugin/SQLDatabase.swift
+++ b/ios/Sources/CapgoCapacitorFastSqlPlugin/SQLDatabase.swift
@@ -6,9 +6,8 @@ import SQLCipher
 import SQLite3
 #endif
 
-// SQLite constants that aren't imported to Swift
-private let SQLITE_STATIC = unsafeBitCast(0, to: sqlite3_destructor_type.self)
-private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+// SQLite destructor constant that is not imported to Swift
+private let sqliteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 
 /**
  * SQLite database wrapper for iOS
@@ -109,17 +108,17 @@ class SQLDatabase {
             if stepResult == SQLITE_ROW {
                 if columnNames.isEmpty {
                     columnCount = sqlite3_column_count(stmt)
-                    for i in 0..<columnCount {
-                        if let name = sqlite3_column_name(stmt, i) {
+                    for columnIndex in 0..<columnCount {
+                        if let name = sqlite3_column_name(stmt, columnIndex) {
                             columnNames.append(String(cString: name))
                         }
                     }
                 }
 
                 var row: [String: Any] = [:]
-                for i in 0..<columnCount {
-                    let columnName = columnNames[Int(i)]
-                    let value = getColumnValue(stmt: stmt, index: i)
+                for columnIndex in 0..<columnCount {
+                    let columnName = columnNames[Int(columnIndex)]
+                    let value = getColumnValue(stmt: stmt, index: columnIndex)
                     row[columnName] = value
                 }
                 rows.append(row)
@@ -177,7 +176,7 @@ class SQLDatabase {
 
         // Handle different types
         if let str = value as? String {
-            return sqlite3_bind_text(stmt, index, str, -1, SQLITE_TRANSIENT)
+            return sqlite3_bind_text(stmt, index, str, -1, sqliteTransient)
         } else if let num = value as? NSNumber {
             // Check if it's a boolean
             if CFGetTypeID(num as CFTypeRef) == CFBooleanGetTypeID() {
@@ -196,7 +195,7 @@ class SQLDatabase {
                   let data = Data(base64Encoded: base64) {
             // Handle binary data
             return data.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) in
-                sqlite3_bind_blob(stmt, index, bytes.baseAddress, Int32(data.count), SQLITE_TRANSIENT)
+                sqlite3_bind_blob(stmt, index, bytes.baseAddress, Int32(data.count), sqliteTransient)
             }
         }
 

--- a/src/fast-sql.ts
+++ b/src/fast-sql.ts
@@ -14,7 +14,9 @@ import { WebSQLConnection } from './web-sql-connection';
  */
 export class FastSQL {
   private static connections: Map<string, SQLConnection> = new Map();
-  private static connectionRefs: Map<string, number> = new Map();
+  private static sharedConnections: Set<string> = new Set();
+  private static connectionRetainers: Map<string, number> = new Map();
+  private static pendingDisconnects: Set<string> = new Set();
 
   /**
    * Open a database connection
@@ -26,7 +28,7 @@ export class FastSQL {
     // Check if already connected
     const existing = this.connections.get(options.database);
     if (existing) {
-      this.connectionRefs.set(options.database, (this.connectionRefs.get(options.database) ?? 0) + 1);
+      this.sharedConnections.add(options.database);
       return existing;
     }
 
@@ -44,7 +46,6 @@ export class FastSQL {
 
     // Store connection
     this.connections.set(options.database, connection);
-    this.connectionRefs.set(options.database, 1);
 
     return connection;
   }
@@ -60,9 +61,8 @@ export class FastSQL {
       throw new Error(`Database '${database}' is not connected`);
     }
 
-    const refs = (this.connectionRefs.get(database) ?? 1) - 1;
-    if (refs > 0) {
-      this.connectionRefs.set(database, refs);
+    if ((this.connectionRetainers.get(database) ?? 0) > 0) {
+      this.pendingDisconnects.add(database);
       return;
     }
 
@@ -71,7 +71,9 @@ export class FastSQL {
 
     // Remove connection
     this.connections.delete(database);
-    this.connectionRefs.delete(database);
+    this.sharedConnections.delete(database);
+    this.connectionRetainers.delete(database);
+    this.pendingDisconnects.delete(database);
   }
 
   /**
@@ -85,13 +87,50 @@ export class FastSQL {
   }
 
   /**
+   * Check whether a connection has been handed out more than once.
+   */
+  static isConnectionShared(database: string): boolean {
+    return this.sharedConnections.has(database);
+  }
+
+  /**
+   * Temporarily retain a connection for helpers that share cached connections.
+   */
+  static retainConnection(database: string): void {
+    if (!this.connections.has(database)) {
+      throw new Error(`Database '${database}' is not connected`);
+    }
+    this.connectionRetainers.set(database, (this.connectionRetainers.get(database) ?? 0) + 1);
+  }
+
+  /**
+   * Release a retained connection. Returns true when a pending disconnect closed it.
+   */
+  static async releaseConnection(database: string): Promise<boolean> {
+    const retainers = this.connectionRetainers.get(database) ?? 0;
+    if (retainers > 1) {
+      this.connectionRetainers.set(database, retainers - 1);
+      return false;
+    }
+
+    this.connectionRetainers.delete(database);
+    if (this.pendingDisconnects.has(database)) {
+      this.pendingDisconnects.delete(database);
+      await this.disconnect(database);
+      return true;
+    }
+    return false;
+  }
+
+  /**
    * Close all open connections
    */
   static async disconnectAll(): Promise<void> {
     const databases = Array.from(this.connections.keys());
     await Promise.all(
       databases.map((db) => {
-        this.connectionRefs.set(db, 1);
+        this.connectionRetainers.delete(db);
+        this.pendingDisconnects.delete(db);
         return this.disconnect(db);
       }),
     );

--- a/src/fast-sql.ts
+++ b/src/fast-sql.ts
@@ -14,6 +14,7 @@ import { WebSQLConnection } from './web-sql-connection';
  */
 export class FastSQL {
   private static connections: Map<string, SQLConnection> = new Map();
+  private static connectionRefs: Map<string, number> = new Map();
 
   /**
    * Open a database connection
@@ -25,6 +26,7 @@ export class FastSQL {
     // Check if already connected
     const existing = this.connections.get(options.database);
     if (existing) {
+      this.connectionRefs.set(options.database, (this.connectionRefs.get(options.database) ?? 0) + 1);
       return existing;
     }
 
@@ -42,6 +44,7 @@ export class FastSQL {
 
     // Store connection
     this.connections.set(options.database, connection);
+    this.connectionRefs.set(options.database, 1);
 
     return connection;
   }
@@ -57,11 +60,18 @@ export class FastSQL {
       throw new Error(`Database '${database}' is not connected`);
     }
 
+    const refs = (this.connectionRefs.get(database) ?? 1) - 1;
+    if (refs > 0) {
+      this.connectionRefs.set(database, refs);
+      return;
+    }
+
     // Disconnect via native plugin
     await CapgoCapacitorFastSql.disconnect({ database });
 
     // Remove connection
     this.connections.delete(database);
+    this.connectionRefs.delete(database);
   }
 
   /**
@@ -79,7 +89,12 @@ export class FastSQL {
    */
   static async disconnectAll(): Promise<void> {
     const databases = Array.from(this.connections.keys());
-    await Promise.all(databases.map((db) => this.disconnect(db)));
+    await Promise.all(
+      databases.map((db) => {
+        this.connectionRefs.set(db, 1);
+        return this.disconnect(db);
+      }),
+    );
   }
 
   /**

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,3 +5,17 @@
 
 export { FastSQL } from './fast-sql';
 export { SQLConnection } from './sql-connection';
+export { FastSQLVectorStore } from './vector-store';
+export type {
+  VectorEmbeddings,
+  VectorMetadata,
+  VectorStore,
+  VectorStoreAddOptions,
+  VectorStoreConnectionOptions,
+  VectorStoreDeleteOptions,
+  VectorStoreGetResult,
+  VectorStoreOptions,
+  VectorStoreQueryOptions,
+  VectorStoreQueryResult,
+  VectorStoreUpdateOptions,
+} from './vector-store';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,17 @@ export { NativeSQLConnection } from './native-sql-connection';
 export { WebSQLConnection } from './web-sql-connection';
 export { KeyValueStore } from './key-value';
 export type { KeyValueStoreOptions, KeyValueValue } from './key-value';
+export { FastSQLVectorStore } from './vector-store';
+export type {
+  VectorEmbeddings,
+  VectorMetadata,
+  VectorStore,
+  VectorStoreAddOptions,
+  VectorStoreConnectionOptions,
+  VectorStoreDeleteOptions,
+  VectorStoreGetResult,
+  VectorStoreOptions,
+  VectorStoreQueryOptions,
+  VectorStoreQueryResult,
+  VectorStoreUpdateOptions,
+} from './vector-store';

--- a/src/vector-store.ts
+++ b/src/vector-store.ts
@@ -89,8 +89,6 @@ export interface VectorStore {
  * share one database by choosing different `store` names.
  */
 export class FastSQLVectorStore implements VectorStore {
-  private static readonly connectionRefs = new Map<string, number>();
-
   private readonly connection: SQLConnection;
   private readonly store: string;
   private readonly embeddings?: VectorEmbeddings;
@@ -108,21 +106,6 @@ export class FastSQLVectorStore implements VectorStore {
     this.embeddingDim = options.embeddingDimension;
   }
 
-  private static retainConnection(database: string): void {
-    this.connectionRefs.set(database, (this.connectionRefs.get(database) ?? 0) + 1);
-  }
-
-  private static async releaseConnection(database: string): Promise<void> {
-    const refs = this.connectionRefs.get(database) ?? 0;
-    if (refs > 1) {
-      this.connectionRefs.set(database, refs - 1);
-      return;
-    }
-
-    this.connectionRefs.delete(database);
-    await FastSQL.disconnect(database);
-  }
-
   /**
    * Open a vector store from database connection options.
    */
@@ -130,8 +113,6 @@ export class FastSQLVectorStore implements VectorStore {
     const connection = await FastSQL.connect(options);
     const vectorStore = new FastSQLVectorStore(connection, options);
     vectorStore.ownsConnection = true;
-    FastSQLVectorStore.retainConnection(connection.getDatabaseName());
-
     try {
       await vectorStore.load();
       return vectorStore;
@@ -182,7 +163,7 @@ export class FastSQLVectorStore implements VectorStore {
 
     await this.embeddings?.unload?.();
     if (this.ownsConnection) {
-      await FastSQLVectorStore.releaseConnection(this.connection.getDatabaseName());
+      await FastSQL.disconnect(this.connection.getDatabaseName());
     }
     this.initialized = false;
     this.closed = true;

--- a/src/vector-store.ts
+++ b/src/vector-store.ts
@@ -89,6 +89,9 @@ export interface VectorStore {
  * share one database by choosing different `store` names.
  */
 export class FastSQLVectorStore implements VectorStore {
+  private static readonly connectionRefs = new Map<string, number>();
+  private static readonly ownedConnections = new Set<string>();
+
   private readonly connection: SQLConnection;
   private readonly store: string;
   private readonly embeddings?: VectorEmbeddings;
@@ -96,6 +99,7 @@ export class FastSQLVectorStore implements VectorStore {
   private embeddingDim?: number;
   private initialized = false;
   private ownsConnection = false;
+  private shouldDisconnectConnection = false;
   private closed = false;
 
   private constructor(connection: SQLConnection, options: VectorStoreConnectionOptions = {}) {
@@ -106,13 +110,38 @@ export class FastSQLVectorStore implements VectorStore {
     this.embeddingDim = options.embeddingDimension;
   }
 
+  private static retainConnection(database: string): void {
+    this.connectionRefs.set(database, (this.connectionRefs.get(database) ?? 0) + 1);
+  }
+
+  private static releaseConnection(database: string): boolean {
+    const refs = this.connectionRefs.get(database) ?? 0;
+    if (refs > 1) {
+      this.connectionRefs.set(database, refs - 1);
+      return false;
+    }
+
+    this.connectionRefs.delete(database);
+    this.ownedConnections.delete(database);
+    return true;
+  }
+
   /**
    * Open a vector store from database connection options.
    */
   static async open(options: VectorStoreOptions): Promise<FastSQLVectorStore> {
-    const connection = await FastSQL.connect(options);
+    const existing = FastSQL.getConnection(options.database);
+    const ownsExistingVectorConnection = existing && FastSQLVectorStore.connectionRefs.has(options.database);
+    const connection = ownsExistingVectorConnection ? existing : await FastSQL.connect(options);
     const vectorStore = new FastSQLVectorStore(connection, options);
     vectorStore.ownsConnection = true;
+    vectorStore.shouldDisconnectConnection = !existing || FastSQLVectorStore.ownedConnections.has(options.database);
+    FastSQLVectorStore.retainConnection(connection.getDatabaseName());
+    FastSQL.retainConnection(connection.getDatabaseName());
+    if (vectorStore.shouldDisconnectConnection) {
+      FastSQLVectorStore.ownedConnections.add(connection.getDatabaseName());
+    }
+
     try {
       await vectorStore.load();
       return vectorStore;
@@ -163,7 +192,17 @@ export class FastSQLVectorStore implements VectorStore {
 
     await this.embeddings?.unload?.();
     if (this.ownsConnection) {
-      await FastSQL.disconnect(this.connection.getDatabaseName());
+      const database = this.connection.getDatabaseName();
+      const releasedLastVectorStore = FastSQLVectorStore.releaseConnection(database);
+      const closedFromPendingDisconnect = await FastSQL.releaseConnection(database);
+      if (
+        releasedLastVectorStore &&
+        this.shouldDisconnectConnection &&
+        !FastSQL.isConnectionShared(database) &&
+        !closedFromPendingDisconnect
+      ) {
+        await FastSQL.disconnect(database);
+      }
     }
     this.initialized = false;
     this.closed = true;

--- a/src/vector-store.ts
+++ b/src/vector-store.ts
@@ -1,0 +1,528 @@
+import type { SQLConnectionOptions, SQLRow, SQLValue } from './definitions';
+import { FastSQL } from './fast-sql';
+import type { SQLConnection } from './sql-connection';
+
+const DEFAULT_STORE = 'default';
+const VECTOR_TABLE = '__fast_sql_vector_store';
+const VECTOR_META_TABLE = '__fast_sql_vector_store_meta';
+
+export type VectorMetadata = Record<string, unknown>;
+
+export interface VectorEmbeddings {
+  load?: () => Promise<unknown> | unknown;
+  unload?: () => Promise<unknown> | unknown;
+  embed: (text: string) => Promise<number[]> | number[];
+}
+
+export interface VectorStoreGetResult {
+  id: string;
+  document: string;
+  embedding: number[];
+  metadata?: VectorMetadata;
+}
+
+export interface VectorStoreQueryResult extends VectorStoreGetResult {
+  similarity: number;
+}
+
+export interface VectorStoreAddOptions {
+  id?: string;
+  document?: string;
+  embedding?: number[];
+  metadata?: VectorMetadata | null;
+}
+
+export interface VectorStoreUpdateOptions {
+  id: string;
+  document?: string;
+  embedding?: number[];
+  metadata?: VectorMetadata | null;
+}
+
+export interface VectorStoreDeleteOptions {
+  predicate: (value: VectorStoreGetResult) => boolean;
+}
+
+export interface VectorStoreQueryOptions {
+  queryText?: string;
+  queryEmbedding?: number[];
+  nResults?: number;
+  predicate?: (value: VectorStoreQueryResult) => boolean;
+}
+
+export interface VectorStoreConnectionOptions {
+  /**
+   * Logical vector store name inside the database. Use different names to keep
+   * multiple RAG collections in the same SQLite database.
+   */
+  store?: string;
+
+  /**
+   * Optional embeddings provider. Required when adding or querying by text.
+   */
+  embeddings?: VectorEmbeddings;
+
+  /**
+   * Optional embedding dimension. Supplying it avoids probing the embeddings
+   * model on load and allows precomputed-embedding-only stores.
+   */
+  embeddingDimension?: number;
+}
+
+export interface VectorStoreOptions extends SQLConnectionOptions, VectorStoreConnectionOptions {}
+
+export interface VectorStore {
+  load(): Promise<this>;
+  unload(): Promise<void>;
+  add(params: VectorStoreAddOptions): Promise<string>;
+  update(params: VectorStoreUpdateOptions): Promise<void>;
+  delete(params: VectorStoreDeleteOptions): Promise<void>;
+  query(params: VectorStoreQueryOptions): Promise<VectorStoreQueryResult[]>;
+  deleteVectorStore(): Promise<void>;
+}
+
+/**
+ * SQLite-backed VectorStore for local RAG usage.
+ *
+ * The helper is optional and dependency-free: pass your own embeddings provider,
+ * or use precomputed embeddings with `embeddingDimension`. Multiple stores can
+ * share one database by choosing different `store` names.
+ */
+export class FastSQLVectorStore implements VectorStore {
+  private static readonly connectionRefs = new Map<string, number>();
+
+  private readonly connection: SQLConnection;
+  private readonly store: string;
+  private readonly embeddings?: VectorEmbeddings;
+  private readonly configuredEmbeddingDim?: number;
+  private embeddingDim?: number;
+  private initialized = false;
+  private ownsConnection = false;
+  private closed = false;
+
+  private constructor(connection: SQLConnection, options: VectorStoreConnectionOptions = {}) {
+    this.connection = connection;
+    this.store = options.store ?? DEFAULT_STORE;
+    this.embeddings = options.embeddings;
+    this.configuredEmbeddingDim = options.embeddingDimension;
+    this.embeddingDim = options.embeddingDimension;
+  }
+
+  private static retainConnection(database: string): void {
+    this.connectionRefs.set(database, (this.connectionRefs.get(database) ?? 0) + 1);
+  }
+
+  private static async releaseConnection(database: string): Promise<void> {
+    const refs = this.connectionRefs.get(database) ?? 0;
+    if (refs > 1) {
+      this.connectionRefs.set(database, refs - 1);
+      return;
+    }
+
+    this.connectionRefs.delete(database);
+    await FastSQL.disconnect(database);
+  }
+
+  /**
+   * Open a vector store from database connection options.
+   */
+  static async open(options: VectorStoreOptions): Promise<FastSQLVectorStore> {
+    const connection = await FastSQL.connect(options);
+    const vectorStore = new FastSQLVectorStore(connection, options);
+    vectorStore.ownsConnection = true;
+    FastSQLVectorStore.retainConnection(connection.getDatabaseName());
+
+    try {
+      await vectorStore.load();
+      return vectorStore;
+    } catch (error) {
+      await vectorStore.unload();
+      throw error;
+    }
+  }
+
+  /**
+   * Create a vector store from an existing SQL connection.
+   * The caller keeps ownership of the connection.
+   */
+  static async fromConnection(
+    connection: SQLConnection,
+    options: VectorStoreConnectionOptions = {},
+  ): Promise<FastSQLVectorStore> {
+    const vectorStore = new FastSQLVectorStore(connection, options);
+    await vectorStore.load();
+    return vectorStore;
+  }
+
+  getStoreName(): string {
+    return this.store;
+  }
+
+  getDatabaseName(): string {
+    return this.connection.getDatabaseName();
+  }
+
+  async load(): Promise<this> {
+    this.assertOpen();
+    if (this.initialized) {
+      return this;
+    }
+
+    await this.embeddings?.load?.();
+    await this.ensureSchema();
+    await this.ensureStoreDimension();
+    this.initialized = true;
+    return this;
+  }
+
+  async unload(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+
+    await this.embeddings?.unload?.();
+    if (this.ownsConnection) {
+      await FastSQLVectorStore.releaseConnection(this.connection.getDatabaseName());
+    }
+    this.initialized = false;
+    this.closed = true;
+  }
+
+  async close(): Promise<void> {
+    await this.unload();
+  }
+
+  async add(params: VectorStoreAddOptions): Promise<string> {
+    await this.ensureReady();
+    const { id = this.createId(), document, embedding, metadata } = params;
+
+    if (document === undefined && embedding === undefined) {
+      throw new Error('document and embedding cannot both be undefined');
+    }
+
+    const existing = await this.connection.query(`SELECT 1 FROM ${VECTOR_TABLE} WHERE store = ? AND id = ? LIMIT 1`, [
+      this.store,
+      id,
+    ]);
+    if (existing.length > 0) {
+      throw new Error(`id already exists: ${id}`);
+    }
+
+    const resolvedEmbedding = embedding ?? (await this.embedDocument(document));
+    await this.ensureEmbeddingDimension(resolvedEmbedding);
+    const now = Date.now();
+
+    await this.connection.run(
+      `INSERT INTO ${VECTOR_TABLE} (store, id, document, embedding, metadata, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [
+        this.store,
+        id,
+        document ?? '',
+        this.encodeEmbedding(resolvedEmbedding),
+        this.encodeMetadata(metadata),
+        now,
+        now,
+      ],
+    );
+
+    return id;
+  }
+
+  async update(params: VectorStoreUpdateOptions): Promise<void> {
+    await this.ensureReady();
+    const rows = await this.connection.query(
+      `SELECT id, document, embedding, metadata FROM ${VECTOR_TABLE} WHERE store = ? AND id = ? LIMIT 1`,
+      [this.store, params.id],
+    );
+
+    if (rows.length === 0) {
+      throw new Error(`id not found: ${params.id}`);
+    }
+
+    const current = this.rowToGetResult(rows[0]);
+    const document = params.document ?? current.document;
+    const embedding =
+      params.embedding ??
+      (params.document !== undefined ? await this.embedDocument(params.document) : current.embedding);
+    const metadata = params.metadata === undefined ? current.metadata : params.metadata;
+
+    await this.ensureEmbeddingDimension(embedding);
+    await this.connection.run(
+      `UPDATE ${VECTOR_TABLE}
+       SET document = ?, embedding = ?, metadata = ?, updated_at = ?
+       WHERE store = ? AND id = ?`,
+      [document, this.encodeEmbedding(embedding), this.encodeMetadata(metadata), Date.now(), this.store, params.id],
+    );
+  }
+
+  async delete(params: VectorStoreDeleteOptions): Promise<void> {
+    await this.ensureReady();
+    const rows = await this.getStoreRows();
+    const ids = rows
+      .map((row) => this.rowToGetResult(row))
+      .filter(params.predicate)
+      .map((row) => row.id);
+
+    for (const id of ids) {
+      await this.connection.run(`DELETE FROM ${VECTOR_TABLE} WHERE store = ? AND id = ?`, [this.store, id]);
+    }
+  }
+
+  async query(params: VectorStoreQueryOptions): Promise<VectorStoreQueryResult[]> {
+    await this.ensureReady();
+    const { queryText, queryEmbedding, nResults, predicate } = params;
+
+    if (queryText === undefined && queryEmbedding === undefined) {
+      throw new Error('queryText and queryEmbedding cannot both be undefined');
+    }
+    if (nResults !== undefined && nResults < 0) {
+      throw new Error('nResults cannot be negative');
+    }
+
+    const searchEmbedding = queryEmbedding ?? (await this.embedDocument(queryText));
+    await this.ensureEmbeddingDimension(searchEmbedding);
+
+    const results = (await this.getStoreRows())
+      .map((row) => {
+        const item = this.rowToGetResult(row);
+        return {
+          ...item,
+          similarity: this.cosineSimilarity(item.embedding, searchEmbedding),
+        };
+      })
+      .filter(predicate ?? (() => true))
+      .sort((a, b) => b.similarity - a.similarity);
+
+    return nResults === undefined ? results : results.slice(0, nResults);
+  }
+
+  /**
+   * Delete only this logical vector store. Other stores in the same database stay intact.
+   */
+  async deleteVectorStore(): Promise<void> {
+    await this.ensureReady();
+    await this.connection.run(`DELETE FROM ${VECTOR_TABLE} WHERE store = ?`, [this.store]);
+    await this.connection.run(`DELETE FROM ${VECTOR_META_TABLE} WHERE store = ?`, [this.store]);
+    this.embeddingDim = this.configuredEmbeddingDim;
+    if (this.embeddingDim !== undefined) {
+      await this.saveEmbeddingDimension();
+    }
+  }
+
+  private async ensureReady(): Promise<void> {
+    this.assertOpen();
+    if (!this.initialized) {
+      await this.load();
+    }
+  }
+
+  private assertOpen(): void {
+    if (this.closed) {
+      throw new Error('Vector store is closed');
+    }
+  }
+
+  private async ensureSchema(): Promise<void> {
+    await this.connection.run(
+      `CREATE TABLE IF NOT EXISTS ${VECTOR_TABLE} (
+        store TEXT NOT NULL,
+        id TEXT NOT NULL,
+        document TEXT NOT NULL,
+        embedding BLOB NOT NULL,
+        metadata TEXT DEFAULT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (store, id)
+      )`,
+    );
+    await this.connection.run(`CREATE INDEX IF NOT EXISTS ${VECTOR_TABLE}_store_idx ON ${VECTOR_TABLE} (store)`);
+    await this.connection.run(
+      `CREATE TABLE IF NOT EXISTS ${VECTOR_META_TABLE} (
+        store TEXT PRIMARY KEY,
+        embedding_dim INTEGER NOT NULL
+      )`,
+    );
+  }
+
+  private async ensureStoreDimension(): Promise<void> {
+    const rows = await this.connection.query(`SELECT embedding_dim FROM ${VECTOR_META_TABLE} WHERE store = ? LIMIT 1`, [
+      this.store,
+    ]);
+    const storedDim = this.parseStoredDimension(rows[0]);
+
+    if (storedDim !== undefined && this.embeddingDim !== undefined && storedDim !== this.embeddingDim) {
+      throw new Error(`embedding dimension ${this.embeddingDim} does not match existing store dimension ${storedDim}`);
+    }
+
+    if (this.embeddingDim === undefined) {
+      this.embeddingDim = storedDim ?? (this.embeddings ? (await this.embedDocument('dummy')).length : undefined);
+    }
+
+    if (this.embeddingDim !== undefined) {
+      await this.saveEmbeddingDimension();
+    }
+  }
+
+  private parseStoredDimension(row?: SQLRow): number | undefined {
+    if (!row) {
+      return undefined;
+    }
+
+    const value = row.embedding_dim;
+    if (typeof value === 'number') {
+      return value;
+    }
+    if (typeof value === 'string') {
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : undefined;
+    }
+    return undefined;
+  }
+
+  private async saveEmbeddingDimension(): Promise<void> {
+    if (this.embeddingDim === undefined) {
+      return;
+    }
+
+    await this.connection.run(`INSERT OR REPLACE INTO ${VECTOR_META_TABLE} (store, embedding_dim) VALUES (?, ?)`, [
+      this.store,
+      this.embeddingDim,
+    ]);
+  }
+
+  private async ensureEmbeddingDimension(embedding: number[]): Promise<void> {
+    this.validateEmbedding(embedding);
+
+    if (this.embeddingDim === undefined) {
+      this.embeddingDim = embedding.length;
+      await this.saveEmbeddingDimension();
+      return;
+    }
+
+    if (embedding.length !== this.embeddingDim) {
+      throw new Error(
+        `embedding dimension ${embedding.length} does not match vector store dimension ${this.embeddingDim}`,
+      );
+    }
+  }
+
+  private async embedDocument(document: string | undefined): Promise<number[]> {
+    if (document === undefined) {
+      throw new Error('document is required when embedding is not provided');
+    }
+    if (!this.embeddings) {
+      throw new Error('embeddings provider is required for text operations');
+    }
+
+    return this.embeddings.embed(document);
+  }
+
+  private validateEmbedding(embedding: number[]): void {
+    if (!Array.isArray(embedding) || embedding.length === 0) {
+      throw new Error('embedding must be a non-empty number array');
+    }
+
+    for (const value of embedding) {
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        throw new Error('embedding values must be finite numbers');
+      }
+    }
+  }
+
+  private async getStoreRows(): Promise<SQLRow[]> {
+    return this.connection.query(
+      `SELECT id, document, embedding, metadata FROM ${VECTOR_TABLE} WHERE store = ? ORDER BY updated_at DESC`,
+      [this.store],
+    );
+  }
+
+  private rowToGetResult(row: SQLRow): VectorStoreGetResult {
+    const result: VectorStoreGetResult = {
+      id: String(row.id),
+      document: row.document === null || row.document === undefined ? '' : String(row.document),
+      embedding: this.decodeEmbedding(row.embedding),
+    };
+
+    const metadata = this.decodeMetadata(row.metadata);
+    if (metadata !== undefined) {
+      result.metadata = metadata;
+    }
+
+    return result;
+  }
+
+  private encodeEmbedding(embedding: number[]): Uint8Array {
+    const bytes = new Uint8Array(embedding.length * Float32Array.BYTES_PER_ELEMENT);
+    const view = new DataView(bytes.buffer);
+    embedding.forEach((value, index) => view.setFloat32(index * Float32Array.BYTES_PER_ELEMENT, value, true));
+    return bytes;
+  }
+
+  private decodeEmbedding(value: SQLValue | undefined): number[] {
+    if (!(value instanceof Uint8Array)) {
+      throw new Error('stored embedding is not binary data');
+    }
+    if (value.byteLength % Float32Array.BYTES_PER_ELEMENT !== 0) {
+      throw new Error('stored embedding has invalid byte length');
+    }
+
+    const view = new DataView(value.buffer, value.byteOffset, value.byteLength);
+    const embedding: number[] = [];
+    for (let offset = 0; offset < value.byteLength; offset += Float32Array.BYTES_PER_ELEMENT) {
+      embedding.push(view.getFloat32(offset, true));
+    }
+    return embedding;
+  }
+
+  private encodeMetadata(metadata: VectorMetadata | null | undefined): string | null {
+    return metadata ? JSON.stringify(metadata) : null;
+  }
+
+  private decodeMetadata(value: SQLValue | undefined): VectorMetadata | undefined {
+    if (typeof value !== 'string' || value.length === 0) {
+      return undefined;
+    }
+
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private cosineSimilarity(a: number[], b: number[]): number {
+    if (a.length !== b.length) {
+      throw new Error(`embedding dimension ${b.length} does not match stored embedding dimension ${a.length}`);
+    }
+
+    let dot = 0;
+    let normA = 0;
+    let normB = 0;
+    for (let i = 0; i < a.length; i++) {
+      dot += a[i] * b[i];
+      normA += a[i] * a[i];
+      normB += b[i] * b[i];
+    }
+
+    if (normA === 0 || normB === 0) {
+      return 0;
+    }
+
+    return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+  }
+
+  private createId(): string {
+    const cryptoApi = globalThis.crypto as Crypto | undefined;
+    if (typeof cryptoApi?.randomUUID === 'function') {
+      return cryptoApi.randomUUID();
+    }
+
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (char) => {
+      const value = Math.floor(Math.random() * 16);
+      const nibble = char === 'x' ? value : (value & 0x3) | 0x8;
+      return nibble.toString(16);
+    });
+  }
+}


### PR DESCRIPTION
## What
- Add `FastSQLVectorStore`, an optional SQLite-backed VectorStore helper for local RAG usage.
- Support many named vector stores in the same FastSQL database through the `store` namespace.
- Store embeddings as binary Float32 vectors with metadata and cosine-similarity querying in TypeScript.
- Export the helper/types from the main entrypoint and helpers entrypoint.
- Fix small SwiftLint serious identifier violations in `SQLDatabase.swift` so CI lint can pass.

## Why
- Users need persistent local RAG storage without requiring a native vector extension or a hard dependency on a specific RAG library.
- Named stores let apps keep separate collections, such as docs, tickets, and offline embeddings, in one SQLite database.

## How
- Model the API after the `@react-native-rag/op-sqlite` VectorStore shape while keeping it dependency-free.
- Add `open()` for owned FastSQL connections and `fromConnection()` for callers that already manage a connection.
- Keep vector-store-owned shared database connections alive until the last opened store closes.
- Validate embedding dimensions per store and persist them in a small metadata table.

## Testing
- `bun run lint`
- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ANDROID_HOME='/Users/martindonadieu/Library/Android/sdk' bun run verify`
- `bun run check:wiring`

## Not Tested
- Runtime retrieval in a real app with a production embeddings model.
