### PR TITLE
fix(ios): keep HTTP server databases in sync across connect/disconnect

### DIFF
--- a/ios/Sources/CapgoCapacitorFastSqlPlugin/CapgoCapacitorFastSqlPlugin.swift
+++ b/ios/Sources/CapgoCapacitorFastSqlPlugin/CapgoCapacitorFastSqlPlugin.swift
@@ -59,16 +59,24 @@ public class CapgoCapacitorFastSqlPlugin: CAPPlugin, CAPBridgedPlugin {
 
             // Open database
             let db = try SQLDatabase(path: dbPath, encrypted: encrypted, encryptionKey: encryptionKey)
-            databases[database] = db
 
             // Start HTTP server if not already running, otherwise register the
             // new database with it. SQLHTTPServer stores a VALUE COPY of the
             // databases dict (Swift Dict is a value type), so every connect()
             // after server creation must push the new entry in explicitly.
+            //
+            // Instance state (databases, server) is only mutated AFTER both the
+            // server initialisation and start succeed, preventing a corrupted state
+            // if either step throws.
             if server == nil {
-                server = try SQLHTTPServer(databases: databases)
-                try server?.start()
+                var initialDatabases = databases
+                initialDatabases[database] = db
+                let newServer = try SQLHTTPServer(databases: initialDatabases)
+                try newServer.start()
+                databases[database] = db
+                server = newServer
             } else {
+                databases[database] = db
                 server?.addDatabase(db, forKey: database)
             }
 

--- a/ios/Sources/CapgoCapacitorFastSqlPlugin/CapgoCapacitorFastSqlPlugin.swift
+++ b/ios/Sources/CapgoCapacitorFastSqlPlugin/CapgoCapacitorFastSqlPlugin.swift
@@ -61,10 +61,15 @@ public class CapgoCapacitorFastSqlPlugin: CAPPlugin, CAPBridgedPlugin {
             let db = try SQLDatabase(path: dbPath, encrypted: encrypted, encryptionKey: encryptionKey)
             databases[database] = db
 
-            // Start HTTP server if not already running
+            // Start HTTP server if not already running, otherwise register the
+            // new database with it. SQLHTTPServer stores a VALUE COPY of the
+            // databases dict (Swift Dict is a value type), so every connect()
+            // after server creation must push the new entry in explicitly.
             if server == nil {
                 server = try SQLHTTPServer(databases: databases)
                 try server?.start()
+            } else {
+                server?.addDatabase(db, forKey: database)
             }
 
             guard let server = server else {
@@ -95,6 +100,7 @@ public class CapgoCapacitorFastSqlPlugin: CAPPlugin, CAPBridgedPlugin {
 
         db.close()
         databases.removeValue(forKey: database)
+        server?.removeDatabase(forKey: database)
 
         // Stop server if no more databases
         if databases.isEmpty {

--- a/ios/Sources/CapgoCapacitorFastSqlPlugin/SQLHTTPServer.swift
+++ b/ios/Sources/CapgoCapacitorFastSqlPlugin/SQLHTTPServer.swift
@@ -12,6 +12,7 @@ class SQLHTTPServer {
     let port: Int
     let token: String
     private var databases: [String: SQLDatabase]
+    private let databasesLock = NSLock()
     private var server: Server?
     private var isRunning = false
 
@@ -24,12 +25,32 @@ class SQLHTTPServer {
         self.server = Server()
     }
 
+    /// Registers a newly-connected database with the HTTP server.
+    ///
+    /// Must be called after every `connect()` that finds the server already running,
+    /// because `SQLHTTPServer` holds a **value-type copy** of the databases dictionary
+    /// and cannot observe subsequent mutations made to the plugin's own copy.
     func addDatabase(_ db: SQLDatabase, forKey key: String) {
+        databasesLock.lock()
+        defer { databasesLock.unlock() }
         databases[key] = db
     }
 
+    /// Removes a disconnected database from the HTTP server's registry.
+    ///
+    /// Call whenever a database is disconnected so in-flight HTTP requests for it
+    /// receive a timely "not found" response rather than accessing a closed handle.
     func removeDatabase(forKey key: String) {
+        databasesLock.lock()
+        defer { databasesLock.unlock() }
         databases.removeValue(forKey: key)
+    }
+
+    /// Returns the open database for `key`, or `nil` if not registered.
+    private func database(forKey key: String) -> SQLDatabase? {
+        databasesLock.lock()
+        defer { databasesLock.unlock() }
+        return databases[key]
     }
 
     func start() throws {
@@ -188,7 +209,7 @@ class SQLHTTPServer {
         }
 
         // Check if database exists
-        guard let db = databases[database] else {
+        guard let db = database(forKey: database) else {
             let bodyData = "Database not found".data(using: .utf8)!
             return HTTPResponse(.notFound, body: bodyData)
         }
@@ -227,7 +248,7 @@ class SQLHTTPServer {
         }
 
         // Check if database exists
-        guard let db = databases[database] else {
+        guard let db = database(forKey: database) else {
             let bodyData = "Database not found".data(using: .utf8)!
             return HTTPResponse(.notFound, body: bodyData)
         }
@@ -275,7 +296,7 @@ class SQLHTTPServer {
         }
 
         // Check if database exists
-        guard let db = databases[database] else {
+        guard let db = database(forKey: database) else {
             let bodyData = "Database not found".data(using: .utf8)!
             return HTTPResponse(.notFound, body: bodyData)
         }
@@ -304,7 +325,7 @@ class SQLHTTPServer {
         }
 
         // Check if database exists
-        guard let db = databases[database] else {
+        guard let db = database(forKey: database) else {
             let bodyData = "Database not found".data(using: .utf8)!
             return HTTPResponse(.notFound, body: bodyData)
         }
@@ -333,7 +354,7 @@ class SQLHTTPServer {
         }
 
         // Check if database exists
-        guard let db = databases[database] else {
+        guard let db = database(forKey: database) else {
             let bodyData = "Database not found".data(using: .utf8)!
             return HTTPResponse(.notFound, body: bodyData)
         }

--- a/ios/Sources/CapgoCapacitorFastSqlPlugin/SQLHTTPServer.swift
+++ b/ios/Sources/CapgoCapacitorFastSqlPlugin/SQLHTTPServer.swift
@@ -24,6 +24,14 @@ class SQLHTTPServer {
         self.server = Server()
     }
 
+    func addDatabase(_ db: SQLDatabase, forKey key: String) {
+        databases[key] = db
+    }
+
+    func removeDatabase(forKey key: String) {
+        databases.removeValue(forKey: key)
+    }
+
     func start() throws {
         guard !isRunning else { return }
         guard let server = server else {


### PR DESCRIPTION
Problem                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                         
  On iOS, SQLHTTPServer receives a value-type copy of the databases dictionary at creation time (Swift Dictionary is a struct). Any database connected after the server is already running is added to the plugin's dictionary but never to the server's 
  frozen copy. Every subsequent SQL call for that database hits the HTTP path and gets back "Database not found".                                                                                                                                        
                                                                                                                                                                                                                                                         
  Android is not affected because Java HashMap is a reference type — the server observes all mutations through the shared reference automatically.                                                                                                       
                                                                                                                                                                                                                                                         
  Fix                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                         
  Add two mutating methods to SQLHTTPServer:                                                                                                                                                                                                             
                                                                                                                                                                                                                                                         
  - addDatabase(_:forKey:) — called from connect() when the server is already running
  - removeDatabase(forKey:) — called from disconnect() before the server is stopped
  
  This keeps the server's databases dict in sync with the plugin's without restarting the server or changing the initialization path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling so newly opened databases are properly registered with an already running local HTTP server.
  * Added explicit database cleanup on disconnect to prevent stale or lingering registrations.
  * Improved HTTP request reliability by synchronizing database access and ensuring endpoints use the lock-protected registry for “not found” checks and SQL operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->