### PR TITLE
fix(ios): keep HTTP server databases in sync across connect/disconnect

### DIFF
--- a/ios/Sources/CapgoCapacitorFastSqlPlugin/CapgoCapacitorFastSqlPlugin.swift
+++ b/ios/Sources/CapgoCapacitorFastSqlPlugin/CapgoCapacitorFastSqlPlugin.swift
@@ -59,12 +59,26 @@ public class CapgoCapacitorFastSqlPlugin: CAPPlugin, CAPBridgedPlugin {
 
             // Open database
             let db = try SQLDatabase(path: dbPath, encrypted: encrypted, encryptionKey: encryptionKey)
-            databases[database] = db
 
-            // Start HTTP server if not already running
-            if server == nil {
-                server = try SQLHTTPServer(databases: databases)
-                try server?.start()
+            // Start HTTP server if not already running, otherwise register the
+            // new database with it. SQLHTTPServer stores a VALUE COPY of the
+            // databases dict (Swift Dict is a value type), so every connect()
+            // after server creation must push the new entry in explicitly.
+            if let server {
+                databases[database] = db
+                server.addDatabase(db, forKey: database)
+            } else {
+                var initialDatabases = databases
+                initialDatabases[database] = db
+                do {
+                    let newServer = try SQLHTTPServer(databases: initialDatabases)
+                    try newServer.start()
+                    databases[database] = db
+                    self.server = newServer
+                } catch {
+                    db.close()
+                    throw error
+                }
             }
 
             guard let server = server else {
@@ -93,8 +107,9 @@ public class CapgoCapacitorFastSqlPlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
 
-        db.close()
+        server?.removeDatabase(forKey: database)
         databases.removeValue(forKey: database)
+        db.close()
 
         // Stop server if no more databases
         if databases.isEmpty {

--- a/ios/Sources/CapgoCapacitorFastSqlPlugin/SQLHTTPServer.swift
+++ b/ios/Sources/CapgoCapacitorFastSqlPlugin/SQLHTTPServer.swift
@@ -12,6 +12,7 @@ class SQLHTTPServer {
     let port: Int
     let token: String
     private var databases: [String: SQLDatabase]
+    private let databasesLock = NSLock()
     private var server: Server?
     private var isRunning = false
 
@@ -22,6 +23,34 @@ class SQLHTTPServer {
 
         // Initialize Telegraph server
         self.server = Server()
+    }
+
+    /// Registers a newly-connected database with the HTTP server.
+    ///
+    /// Must be called after every `connect()` that finds the server already running,
+    /// because `SQLHTTPServer` holds a **value-type copy** of the databases dictionary
+    /// and cannot observe subsequent mutations made to the plugin's own copy.
+    func addDatabase(_ db: SQLDatabase, forKey key: String) {
+        databasesLock.lock()
+        defer { databasesLock.unlock() }
+        databases[key] = db
+    }
+
+    /// Removes a disconnected database from the HTTP server's registry.
+    ///
+    /// Call whenever a database is disconnected so in-flight HTTP requests for it
+    /// receive a timely "not found" response rather than accessing a closed handle.
+    func removeDatabase(forKey key: String) {
+        databasesLock.lock()
+        defer { databasesLock.unlock() }
+        databases.removeValue(forKey: key)
+    }
+
+    /// Returns the open database for `key`, or `nil` if not registered.
+    private func registeredDatabase(forKey key: String) -> SQLDatabase? {
+        databasesLock.lock()
+        defer { databasesLock.unlock() }
+        return databases[key]
     }
 
     func start() throws {
@@ -180,7 +209,7 @@ class SQLHTTPServer {
         }
 
         // Check if database exists
-        guard let db = databases[database] else {
+        guard let db = registeredDatabase(forKey: database) else {
             let bodyData = "Database not found".data(using: .utf8)!
             return HTTPResponse(.notFound, body: bodyData)
         }
@@ -219,7 +248,7 @@ class SQLHTTPServer {
         }
 
         // Check if database exists
-        guard let db = databases[database] else {
+        guard let db = registeredDatabase(forKey: database) else {
             let bodyData = "Database not found".data(using: .utf8)!
             return HTTPResponse(.notFound, body: bodyData)
         }
@@ -267,7 +296,7 @@ class SQLHTTPServer {
         }
 
         // Check if database exists
-        guard let db = databases[database] else {
+        guard let db = registeredDatabase(forKey: database) else {
             let bodyData = "Database not found".data(using: .utf8)!
             return HTTPResponse(.notFound, body: bodyData)
         }
@@ -296,7 +325,7 @@ class SQLHTTPServer {
         }
 
         // Check if database exists
-        guard let db = databases[database] else {
+        guard let db = registeredDatabase(forKey: database) else {
             let bodyData = "Database not found".data(using: .utf8)!
             return HTTPResponse(.notFound, body: bodyData)
         }
@@ -325,7 +354,7 @@ class SQLHTTPServer {
         }
 
         // Check if database exists
-        guard let db = databases[database] else {
+        guard let db = registeredDatabase(forKey: database) else {
             let bodyData = "Database not found".data(using: .utf8)!
             return HTTPResponse(.notFound, body: bodyData)
         }


### PR DESCRIPTION
## Summary

- Fixes iOS bug where databases connected after the HTTP server starts were missing from `SQLHTTPServer`'s registry (Swift `Dictionary` is a value type copied at init).
- Adds `addDatabase` / `removeDatabase` with `NSLock`-protected access for thread-safe runtime updates.
- Defers plugin state mutation until server startup succeeds, closes the DB handle on startup failure, and unregisters before closing on disconnect.

Supersedes #47 (fork PR from @steinerjakob).

## Test plan

- [x] `bun run verify` passes locally (iOS, Android, web)
- [ ] Connect DB A on iOS, then connect DB B — SQL calls on B should succeed via HTTP
- [ ] Disconnect DB B while server still serves DB A — B returns "not found", A still works
- [ ] Disconnect last DB — server stops cleanly


Made with [Cursor](https://cursor.com)