### PR TITLE
feat: WAL mode and performance presets for connect()

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,12 +508,14 @@ on iOS and Android.
 
 Database connection options
 
-| Prop                | Type                 | Description                                                |
-| ------------------- | -------------------- | ---------------------------------------------------------- |
-| **`database`**      | <code>string</code>  | Database name (file will be created in app data directory) |
-| **`encrypted`**     | <code>boolean</code> | Enable encryption (iOS/Android only)                       |
-| **`encryptionKey`** | <code>string</code>  | Encryption key (required if encrypted is true)             |
-| **`readOnly`**      | <code>boolean</code> | Read-only mode                                             |
+| Prop                     | Type                 | Description                                                                                                                                                            | Since  |
+| ------------------------ | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| **`database`**           | <code>string</code>  | Database name (file will be created in app data directory)                                                                                                             |        |
+| **`encrypted`**          | <code>boolean</code> | Enable encryption (iOS/Android only)                                                                                                                                   |        |
+| **`encryptionKey`**      | <code>string</code>  | Encryption key (required if encrypted is true)                                                                                                                         |        |
+| **`readOnly`**           | <code>boolean</code> | Read-only mode                                                                                                                                                         |        |
+| **`walMode`**            | <code>boolean</code> | Enable WAL (Write-Ahead Logging) journal mode for better concurrency and performance. Executes `PRAGMA journal_mode = WAL` immediately after opening the database.     | 8.0.49 |
+| **`performancePresets`** | <code>boolean</code> | Apply recommended SQLite performance PRAGMAs after opening the database: `synchronous = NORMAL`, `busy_timeout = 5000`, `cache_size = -2000`, and `foreign_keys = ON`. | 8.0.49 |
 
 
 #### SQLResult

--- a/android/src/main/java/app/capgo/capacitor/fastsql/CapgoCapacitorFastSqlPlugin.java
+++ b/android/src/main/java/app/capgo/capacitor/fastsql/CapgoCapacitorFastSqlPlugin.java
@@ -33,6 +33,8 @@ public class CapgoCapacitorFastSqlPlugin extends Plugin {
         }
         boolean encrypted = call.getBoolean("encrypted", false);
         String encryptionKey = call.getString("encryptionKey");
+        boolean walMode = call.getBoolean("walMode", false);
+        boolean performancePresets = call.getBoolean("performancePresets", false);
         if (encrypted && (encryptionKey == null || encryptionKey.isEmpty())) {
             call.reject("Encryption key is required when encrypted is true");
             return;
@@ -67,9 +69,9 @@ public class CapgoCapacitorFastSqlPlugin extends Plugin {
                     );
                     return;
                 }
-                db = new EncryptedSQLDatabase(dbFile.getAbsolutePath(), encryptionKey);
+                db = new EncryptedSQLDatabase(dbFile.getAbsolutePath(), encryptionKey, walMode, performancePresets);
             } else {
-                db = new SQLDatabase(dbFile.getAbsolutePath());
+                db = new SQLDatabase(dbFile.getAbsolutePath(), walMode, performancePresets);
             }
             databases.put(database, db);
 

--- a/android/src/main/java/app/capgo/capacitor/fastsql/EncryptedSQLDatabase.java
+++ b/android/src/main/java/app/capgo/capacitor/fastsql/EncryptedSQLDatabase.java
@@ -19,7 +19,7 @@ public class EncryptedSQLDatabase implements DatabaseConnection {
     private SQLiteDatabase db;
     private volatile boolean inTransaction = false;
 
-    public EncryptedSQLDatabase(String path, String encryptionKey) throws Exception {
+    public EncryptedSQLDatabase(String path, String encryptionKey, boolean walMode, boolean performancePresets) throws Exception {
         if (encryptionKey == null || encryptionKey.isEmpty()) {
             throw new Exception("Encryption key is required when encrypted is true");
         }
@@ -35,8 +35,7 @@ public class EncryptedSQLDatabase implements DatabaseConnection {
         }
         byte[] keyBytes = encryptionKey.getBytes(StandardCharsets.UTF_8);
         this.db = SQLiteDatabase.openOrCreateDatabase(path, keyBytes, null, null);
-        // Enable foreign keys
-        db.execSQL("PRAGMA foreign_keys = ON");
+        SQLPerformanceConfig.apply(db::execSQL, walMode, performancePresets);
     }
 
     public void close() {

--- a/android/src/main/java/app/capgo/capacitor/fastsql/SQLDatabase.java
+++ b/android/src/main/java/app/capgo/capacitor/fastsql/SQLDatabase.java
@@ -20,10 +20,9 @@ public class SQLDatabase implements DatabaseConnection {
     private SQLiteDatabase db;
     private volatile boolean inTransaction = false;
 
-    public SQLDatabase(String path) {
+    public SQLDatabase(String path, boolean walMode, boolean performancePresets) throws Exception {
         this.db = SQLiteDatabase.openOrCreateDatabase(path, null);
-        // Enable foreign keys
-        db.execSQL("PRAGMA foreign_keys = ON");
+        SQLPerformanceConfig.apply(db::execSQL, walMode, performancePresets);
     }
 
     public void close() {

--- a/android/src/main/java/app/capgo/capacitor/fastsql/SQLPerformanceConfig.java
+++ b/android/src/main/java/app/capgo/capacitor/fastsql/SQLPerformanceConfig.java
@@ -1,0 +1,28 @@
+package app.capgo.capacitor.fastsql;
+
+/**
+ * Applies optional SQLite performance PRAGMAs at database open time.
+ */
+public final class SQLPerformanceConfig {
+
+    private SQLPerformanceConfig() {}
+
+    public static void apply(PerformancePragmaExecutor executor, boolean walMode, boolean performancePresets) throws Exception {
+        executor.execSQL("PRAGMA foreign_keys = ON");
+
+        if (walMode) {
+            executor.execSQL("PRAGMA journal_mode = WAL");
+        }
+
+        if (performancePresets) {
+            executor.execSQL("PRAGMA synchronous = NORMAL");
+            executor.execSQL("PRAGMA busy_timeout = 5000");
+            executor.execSQL("PRAGMA cache_size = -2000");
+        }
+    }
+
+    @FunctionalInterface
+    public interface PerformancePragmaExecutor {
+        void execSQL(String sql) throws Exception;
+    }
+}

--- a/ios/Sources/CapgoCapacitorFastSqlPlugin/CapgoCapacitorFastSqlPlugin.swift
+++ b/ios/Sources/CapgoCapacitorFastSqlPlugin/CapgoCapacitorFastSqlPlugin.swift
@@ -36,6 +36,8 @@ public class CapgoCapacitorFastSqlPlugin: CAPPlugin, CAPBridgedPlugin {
 
         let encrypted = call.getBool("encrypted") ?? false
         let encryptionKey = call.getString("encryptionKey")
+        let walMode = call.getBool("walMode") ?? false
+        let performancePresets = call.getBool("performancePresets") ?? false
         if encrypted && (encryptionKey == nil || encryptionKey?.isEmpty == true) {
             call.reject("Encryption key is required when encryption is enabled")
             return
@@ -58,7 +60,13 @@ public class CapgoCapacitorFastSqlPlugin: CAPPlugin, CAPBridgedPlugin {
             let dbPath = try getDatabasePath(database)
 
             // Open database
-            let db = try SQLDatabase(path: dbPath, encrypted: encrypted, encryptionKey: encryptionKey)
+            let db = try SQLDatabase(
+                path: dbPath,
+                encrypted: encrypted,
+                encryptionKey: encryptionKey,
+                walMode: walMode,
+                performancePresets: performancePresets
+            )
 
             // Start HTTP server if not already running, otherwise register the
             // new database with it. SQLHTTPServer stores a VALUE COPY of the

--- a/ios/Sources/CapgoCapacitorFastSqlPlugin/SQLDatabase.swift
+++ b/ios/Sources/CapgoCapacitorFastSqlPlugin/SQLDatabase.swift
@@ -17,7 +17,13 @@ class SQLDatabase {
     private let path: String
     private var inTransaction = false
 
-    init(path: String, encrypted: Bool = false, encryptionKey: String? = nil) throws {
+    init(
+        path: String,
+        encrypted: Bool = false,
+        encryptionKey: String? = nil,
+        walMode: Bool = false,
+        performancePresets: Bool = false
+    ) throws {
         self.path = path
 
         let flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX
@@ -59,9 +65,22 @@ class SQLDatabase {
             #endif
         }
 
-        // Enable foreign keys
-        try execute(statement: "PRAGMA foreign_keys = ON", params: [])
+        try applyPerformanceOptions(walMode: walMode, performancePresets: performancePresets)
         needsClose = false
+    }
+
+    private func applyPerformanceOptions(walMode: Bool, performancePresets: Bool) throws {
+        try execute(statement: "PRAGMA foreign_keys = ON", params: [])
+
+        if walMode {
+            try execute(statement: "PRAGMA journal_mode = WAL", params: [])
+        }
+
+        if performancePresets {
+            try execute(statement: "PRAGMA synchronous = NORMAL", params: [])
+            try execute(statement: "PRAGMA busy_timeout = 5000", params: [])
+            try execute(statement: "PRAGMA cache_size = -2000", params: [])
+        }
     }
 
     func close() {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -68,6 +68,22 @@ export interface SQLConnectionOptions {
    * Read-only mode
    */
   readOnly?: boolean;
+
+  /**
+   * Enable WAL (Write-Ahead Logging) journal mode for better concurrency and performance.
+   * Executes `PRAGMA journal_mode = WAL` immediately after opening the database.
+   *
+   * @since 8.0.49
+   */
+  walMode?: boolean;
+
+  /**
+   * Apply recommended SQLite performance PRAGMAs after opening the database:
+   * `synchronous = NORMAL`, `busy_timeout = 5000`, `cache_size = -2000`, and `foreign_keys = ON`.
+   *
+   * @since 8.0.49
+   */
+  performancePresets?: boolean;
 }
 
 /**

--- a/src/performance-config.ts
+++ b/src/performance-config.ts
@@ -1,0 +1,18 @@
+import type { SQLConnectionOptions } from './definitions';
+
+/**
+ * Apply optional SQLite performance PRAGMAs after opening a database.
+ */
+export function applyPerformanceConfig(db: { run: (sql: string) => void }, options: SQLConnectionOptions): void {
+  db.run('PRAGMA foreign_keys = ON');
+
+  if (options.walMode) {
+    db.run('PRAGMA journal_mode = WAL');
+  }
+
+  if (options.performancePresets) {
+    db.run('PRAGMA synchronous = NORMAL');
+    db.run('PRAGMA busy_timeout = 5000');
+    db.run('PRAGMA cache_size = -2000');
+  }
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -8,6 +8,7 @@ import type {
   IsolationLevel,
   WebConfig,
 } from './definitions';
+import { applyPerformanceConfig } from './performance-config';
 
 const DEFAULT_SQLJS_URL = 'https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.8.0/sql-wasm.js';
 const DEFAULT_WASM_URL = 'https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.8.0/sql-wasm.wasm';
@@ -75,13 +76,14 @@ export class CapgoCapacitorFastSqlWeb extends WebPlugin implements CapgoCapacito
 
     // Check if database already exists in IndexedDB
     const savedData = await this.loadFromIndexedDB(options.database);
-
     let db;
     if (savedData) {
       db = new SQL.Database(savedData);
     } else {
       db = new SQL.Database();
     }
+
+    applyPerformanceConfig(db, options);
 
     const token = this.generateToken();
     const port = this.nextPort++;


### PR DESCRIPTION
## Summary

- Adds optional `walMode` and `performancePresets` flags to `SQLConnectionOptions` (used by `FastSQL.connect()` / `CapgoCapacitorFastSql.connect()`)
- Applies SQLite PRAGMAs at database open time on iOS, Android, and web:
  - `walMode`: `PRAGMA journal_mode = WAL`
  - `performancePresets`: `synchronous = NORMAL`, `busy_timeout = 5000`, `cache_size = -2000`, `foreign_keys = ON`
- Closes #32

## Usage

```typescript
await FastSQL.connect({
  database: 'my_db',
  walMode: true,
  performancePresets: true,
});
```

## Test plan

- [x] `bun run verify` passes locally (iOS, Android, web)
- [ ] CI passes
- [ ] Verify WAL mode on device: `PRAGMA journal_mode` returns `wal` after connect with `walMode: true`


Made with [Cursor](https://cursor.com)